### PR TITLE
Fix epoch accessor

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -9,6 +9,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     name: Build wheels on ${{ matrix.os }}
+    env:
+      TMPDIR: ${{ matrix.os == 'windows-latest' && 'C:\\Windows\\Temp' || '/tmp' }}
 
     steps:
     - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
   "pint-xarray",
   "myst-parser",
 ]
-test = ["pytest >= 3.3.0", "dask[complete]"]
+test = ["pytest >= 3.3.0", "dask[complete]", "matplotlib"]
 lint = ["ruff"]
 build = ["cibuildwheel[uv]"]
 jupyter = ["dask[diagnostics]", "ipykernel>=6.29.5"]

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -15,6 +15,10 @@ from xarray.core import indexing
 from xarray.core.utils import close_on_error, try_read_magic_number_from_path
 from xarray.core.variable import Variable
 
+# NOTE: Do not delete this line, otherwise the "epoch" accessor will not be
+# imported when the user imports sdf_xarray
+import sdf_xarray.plotting  # noqa: F401
+
 from .sdf_interface import Constant, SDFFile  # type: ignore  # noqa: PGH003
 
 

--- a/tests/test_epoch_accessor.py
+++ b/tests/test_epoch_accessor.py
@@ -1,0 +1,37 @@
+import pathlib
+import tempfile
+
+import matplotlib as mpl
+import pytest
+import xarray as xr
+from matplotlib.animation import PillowWriter
+
+from sdf_xarray import SDFPreprocess
+
+mpl.use("Agg")
+
+EXAMPLE_FILES_DIR = pathlib.Path(__file__).parent / "example_files"
+
+
+def test_animation_accessor():
+    array = xr.DataArray(
+        [1, 2, 3],
+        dims=["x"],
+        coords={"x": [0, 1, 2]},
+        attrs={"long_name": "Test Array", "units": "m"},
+    )
+    assert hasattr(array, "epoch")
+    assert hasattr(array.epoch, "animate")
+
+
+def test_animate_headless():
+    with xr.open_mfdataset(
+        EXAMPLE_FILES_DIR.glob("*.sdf"), preprocess=SDFPreprocess()
+    ) as ds:
+        anim = ds["Derived_Number_Density_electron"].epoch.animate()
+
+        with tempfile.NamedTemporaryFile(suffix=".gif") as tmpfile:
+            try:
+                anim.save(tmpfile.name, writer=PillowWriter(fps=2))
+            except Exception as e:
+                pytest.fail(f"animate().save() failed in headless mode: {e}")

--- a/tests/test_epoch_accessor.py
+++ b/tests/test_epoch_accessor.py
@@ -30,8 +30,10 @@ def test_animate_headless():
     ) as ds:
         anim = ds["Derived_Number_Density_electron"].epoch.animate()
 
-        with tempfile.NamedTemporaryFile(suffix=".gif") as tmpfile:
+        # Specify a custom writable temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file_path = f"{temp_dir}/output.gif"
             try:
-                anim.save(tmpfile.name, writer=PillowWriter(fps=2))
+                anim.save(temp_file_path, writer=PillowWriter(fps=2))
             except Exception as e:
                 pytest.fail(f"animate().save() failed in headless mode: {e}")

--- a/uv.lock
+++ b/uv.lock
@@ -901,6 +901,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,6 +1035,27 @@ wheels = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1072,6 +1105,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/40/631c238f1f338eb09f4acb0f34ab5862c4e9d7eda11c1b685471a4c5ea37/msgpack-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4c01941fd2ff87c2a934ee6055bda4ed353a7846b8d4f341c428109e9fcde8c", size = 399082 },
     { url = "https://files.pythonhosted.org/packages/e9/1b/fa8a952be252a1555ed39f97c06778e3aeb9123aa4cccc0fd2acd0b4e315/msgpack-1.1.0-cp313-cp313-win32.whl", hash = "sha256:7c9a35ce2c2573bada929e0b7b3576de647b0defbd25f5139dcdaba0ae35a4cc", size = 69037 },
     { url = "https://files.pythonhosted.org/packages/b6/bc/8bd826dd03e022153bfa1766dcdec4976d6c818865ed54223d71f07862b3/msgpack-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:bce7d9e614a04d0883af0b3d4d501171fbfca038f12c77fa838d9f198147a23f", size = 75140 },
+]
+
+[[package]]
+name = "myst-parser"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579 },
 ]
 
 [[package]]
@@ -1705,7 +1755,7 @@ wheels = [
 
 [[package]]
 name = "sdf-xarray"
-version = "0.2.1.dev11+gf72b842.d20250415"
+version = "0.2.2.dev3+g15f441e"
 source = { editable = "." }
 dependencies = [
     { name = "cython" },
@@ -1721,6 +1771,7 @@ build = [
 docs = [
     { name = "ipython" },
     { name = "matplotlib" },
+    { name = "myst-parser" },
     { name = "pickleshare" },
     { name = "pint" },
     { name = "pint-xarray" },
@@ -1743,6 +1794,7 @@ pint = [
 ]
 test = [
     { name = "dask", extra = ["complete"] },
+    { name = "matplotlib" },
     { name = "pytest" },
 ]
 
@@ -1756,6 +1808,8 @@ requires-dist = [
     { name = "ipykernel", marker = "extra == 'jupyter'", specifier = ">=6.29.5" },
     { name = "ipython", marker = "extra == 'docs'" },
     { name = "matplotlib", marker = "extra == 'docs'" },
+    { name = "matplotlib", marker = "extra == 'test'" },
+    { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "pickleshare", marker = "extra == 'docs'" },
     { name = "pint", marker = "extra == 'docs'" },


### PR DESCRIPTION
In the previous linting fixes (https://github.com/epochpic/sdf-xarray/commit/ac46dfe1e6d9e5f2f1d0b59c9fecebc451b9fe64#diff-dfb7e87e9cedbd8f17cbee7c8f75e363dfd7953b737c64bdf651060977b48c9dL17) I accidentally deleted the above line which causes the `epoch` accessor on the `xarray.DataArray` to stop working unless the user explicitly imports the `plotting` module. This fix remedies that issue by adding the import back in and adds tests to validate the accessor exists.