### PR TITLE
Fix DOI format

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,5 @@ authors:
     given-names: Shaun
     orcid: 'https://orcid.org/0009-0005-0693-030X'
     affiliation: University of York
-identifiers:
-  - type: doi
-    value: 10.5281/zenodo.15351323
+doi: 10.5281/zenodo.15351323
 date-released: '2024-07-25'


### PR DESCRIPTION
For some reason unbeknownst to me the official [CFF](https://citation-file-format.github.io/) website states that DOI's in files need to follow the format in the previous version of the file whereas GitHub expects them to be referred to as the version in this commit. No idea why that's the case but here's a fix to that