### PR TITLE
Pin Cython to 3.0.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "scikit-build-core>=0.3",
   "setuptools_scm",
   "numpy>=2.0.0",
-  "cython>=3.0",
+  "cython==3.0.*",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -22,7 +22,6 @@ dependencies = [
   "numpy>=2.0.0",
   "xarray>=2024.1.0",
   "dask>=2024.7.1",
-  "cython>=3.0",
 ]
 description = "Provides a backend for xarray to read SDF files as created by the EPOCH plasma PIC code."
 classifiers = [


### PR DESCRIPTION
Brought to my attention by @ShaunD137 

A new Cython release seems to have broken everything. As a temporary fix to keep things running, this pins Cython to 3.0.* in the build system and removes it as a runtime dependency (not sure if it's even needed in the regular dependencies?).