### PR TITLE
Improve drop variables

### DIFF
--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -257,8 +257,15 @@ class SDFDataStore(AbstractDataStore):
                 # TODO: nicer error handling
                 self.ds.variables.pop(variable)
 
-        # These two dicts are global metadata about the run or file
-        attrs = {**self.ds.header, **self.ds.run_info}
+                key = _rename_with_underscore(variable)
+                original_name = name_map.get(key)
+
+                if original_name:
+                    self.ds.variables.pop(original_name)
+                else:
+                    raise KeyError(
+                        f"Variable '{variable}' not found (interpreted as '{key}')."
+                    )
 
         data_vars = {}
         coords = {}

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -253,10 +253,10 @@ class SDFDataStore(AbstractDataStore):
     def load(self):  # noqa: PLR0912, PLR0915
         # Drop any requested variables
         if self.drop_variables:
-            for variable in self.drop_variables:
-                # TODO: nicer error handling
-                self.ds.variables.pop(variable)
+            # Build a mapping from underscored names to real variable names
+            name_map = {_rename_with_underscore(var): var for var in self.ds.variables}
 
+            for variable in self.drop_variables:
                 key = _rename_with_underscore(variable)
                 original_name = name_map.get(key)
 
@@ -266,6 +266,9 @@ class SDFDataStore(AbstractDataStore):
                     raise KeyError(
                         f"Variable '{variable}' not found (interpreted as '{key}')."
                     )
+
+        # These two dicts are global metadata about the run or file
+        attrs = {**self.ds.header, **self.ds.run_info}
 
         data_vars = {}
         coords = {}

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -264,7 +264,7 @@ class SDFDataStore(AbstractDataStore):
                     raise KeyError(
                         f"Variable '{variable}' not found (interpreted as '{key}')."
                     )
-                self.ds.variables.pop(original_name)              
+                self.ds.variables.pop(original_name)
 
         # These two dicts are global metadata about the run or file
         attrs = {**self.ds.header, **self.ds.run_info}

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -260,12 +260,11 @@ class SDFDataStore(AbstractDataStore):
                 key = _rename_with_underscore(variable)
                 original_name = name_map.get(key)
 
-                if original_name:
-                    self.ds.variables.pop(original_name)
-                else:
+                if original_name is None:
                     raise KeyError(
                         f"Variable '{variable}' not found (interpreted as '{key}')."
                     )
+                self.ds.variables.pop(original_name)              
 
         # These two dicts are global metadata about the run or file
         attrs = {**self.ds.header, **self.ds.run_info}

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -441,7 +441,7 @@ class SDFEntrypoint(BackendEntrypoint):
 
     description = "Use .sdf files in Xarray"
 
-    url = "https://epochpic.github.io/documentation/visualising_output/python.html"
+    url = "https://epochpic.github.io/documentation/visualising_output/python_beam.html"
 
 
 class SDFPreprocess:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -185,3 +185,37 @@ def test_3d_distribution_function():
     with xr.open_dataset(EXAMPLE_3D_DIST_FN / "0000.sdf") as df:
         distribution_function = "dist_fn_x_px_py_Electron"
         assert df[distribution_function].shape == (16, 20, 20)
+
+
+def test_drop_variables():
+    with xr.open_dataset(
+        EXAMPLE_FILES_DIR / "0000.sdf", drop_variables=["Electric_Field_Ex"]
+    ) as df:
+        assert "Electric_Field_Ex" not in df
+
+
+def test_drop_variables_multiple():
+    with xr.open_dataset(
+        EXAMPLE_FILES_DIR / "0000.sdf",
+        drop_variables=["Electric_Field_Ex", "Electric_Field_Ey"],
+    ) as df:
+        assert "Electric_Field_Ex" not in df
+        assert "Electric_Field_Ey" not in df
+
+
+def test_drop_variables_original():
+    with xr.open_dataset(
+        EXAMPLE_FILES_DIR / "0000.sdf",
+        drop_variables=["Electric_Field/Ex", "Electric_Field/Ey"],
+    ) as df:
+        assert "Electric_Field_Ex" not in df
+        assert "Electric_Field_Ey" not in df
+
+
+def test_drop_variables_mixed():
+    with xr.open_dataset(
+        EXAMPLE_FILES_DIR / "0000.sdf",
+        drop_variables=["Electric_Field/Ex", "Electric_Field_Ey"],
+    ) as df:
+        assert "Electric_Field_Ex" not in df
+        assert "Electric_Field_Ey" not in df

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -219,3 +219,10 @@ def test_drop_variables_mixed():
     ) as df:
         assert "Electric_Field_Ex" not in df
         assert "Electric_Field_Ey" not in df
+
+
+def test_erroring_drop_variables():
+    with pytest.raises(KeyError):
+        xr.open_dataset(
+            EXAMPLE_FILES_DIR / "0000.sdf", drop_variables=["Electric_Field/E"]
+        )


### PR DESCRIPTION
Improve handling of drop_variables parameter to account for both variable types. Previously the user had to drop variables using the SDF_C approach of `Electric_Field/Ex` but the user will probably expect the variables to be in the format of `Electric_Field_Ex`. This function allows for both approaches to work.