### PR TITLE
Support xarray new parameter defaults

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -28,7 +28,7 @@ Usage
 `xarray`. There are several ways to load SDF files:
 
 - To load a single file, use :func:`xarray.open_dataset`.
-- To load multiple files, use :func:`xarray.open_mfdataset` or :func:`sdf_xarray.open_mfdataset`.
+- To load multiple files, use :func:`xarray.open_mfdataset` or :func:`sdf_xarray.open_mfdataset` (Recommended). 
 - To access the raw contents of a single SDF file, use :func:`sdf_xarray.sdf_interface.SDFFile`.
 
 .. note::
@@ -42,21 +42,32 @@ Basic usage:
 .. ipython:: python
 
     import xarray as xr
+    import sdf_xarray as sdfxr
     with xr.open_dataset("tutorial_dataset_1d/0010.sdf") as df:
         print(df["Electric_Field_Ex"])
 
 Multi file loading
 ~~~~~~~~~~~~~~~~~~
 
-To open a whole simulation at once, pass
-``preprocess=sdf_xarray.SDFPreprocess()`` to `xarray.open_mfdataset`:
+To open a whole simulation's files at once use the :func:`sdf_xarray.open_mfdataset` function:
+
+.. ipython:: python
+    
+    sdfxr.open_mfdataset("tutorial_dataset_1d/*.sdf")
+
+You can alternatively open the dataset using the xarray's :func:`xarray.open_mfdataset`
+along with the ``preprocess=sdfxr.SDFPreprocess()``:
 
 .. ipython:: python
 
-    from sdf_xarray import SDFPreprocess
-    xr.open_mfdataset("tutorial_dataset_1d/*.sdf", preprocess=SDFPreprocess())
+    xr.open_mfdataset(
+        "tutorial_dataset_1d/*.sdf",
+        join="outer",
+        compat="no_conflicts",
+        preprocess=sdfxr.SDFPreprocess()
+    )
 
-`SDFPreprocess` checks that all the files are from the same simulation, and
+:class:`sdf_xarray.SDFPreprocess` checks that all the files are from the same simulation, and
 ensures there's a ``time`` dimension so the files are correctly concatenated.
 
 If your simulation has multiple ``output`` blocks so that not all variables are
@@ -64,12 +75,11 @@ output at every time step, then those variables will have ``NaN`` values at the
 corresponding time points.
 
 Alternatively, we can create a separate time dimensions for each ``output``
-block using `sdf_xarray.open_mfdataset` with ``separate_times=True``:
+block using :func:`sdf_xarray.open_mfdataset` with ``separate_times=True``:
 
 .. ipython:: python
 
-    from sdf_xarray import open_mfdataset
-    open_mfdataset("tutorial_dataset_1d/*.sdf", separate_times=True)
+    sdfxr.open_mfdataset("tutorial_dataset_1d/*.sdf", separate_times=True)
 
 This is better for memory consumption, at the cost of perhaps slightly less
 friendly comparisons between variables on different time coordinates.

--- a/docs/key_functionality.rst
+++ b/docs/key_functionality.rst
@@ -6,17 +6,17 @@ Key Functionality
 
 .. ipython:: python
 
+   import xarray as xr
+   import sdf_xarray as sdfxr
    import matplotlib.pyplot as plt
    from IPython.display import display, HTML
-   import xarray as xr
-   from sdf_xarray import SDFFile, SDFPreprocess
 
 Loading SDF Files
 -----------------
 There are several ways to load SDF files:
 
 - To load a single file, use :func:`xarray.open_dataset`.
-- To load multiple files, use :func:`xarray.open_mfdataset` or :func:`sdf_xarray.open_mfdataset`.
+- To load multiple files, use :func:`sdf_xarray.open_mfdataset` or :func:`xarray.open_mfdataset`.
 - To access the raw contents of a single SDF file, use :func:`sdf_xarray.sdf_interface.SDFFile`.
 
 .. note::
@@ -34,28 +34,48 @@ Loading a Single Raw SDF File
 
 .. ipython:: python
 
-   with SDFFile("tutorial_dataset_1d/0010.sdf") as sdf_file:
+   with sdfxr.SDFFile("tutorial_dataset_1d/0010.sdf") as sdf_file:
       print(sdf_file.variables)
 
 Loading all SDF Files for a Simulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When loading in all the files we have do some processing of the data
+Multiple files can be loaded using one of two methods. The first of which
+is by using the :func:`sdf_xarray.open_mfdataset`
+
+.. ipython:: python
+
+   sdfxr.open_mfdataset("tutorial_dataset_1d/*.sdf")
+
+Alternatively files can be loaded using :func:`xarray.open_mfdataset`
+however when loading in all the files we have do some processing of the data
 so that we can correctly align it along the time dimension; This is
 done via the ``preprocess`` parameter.
 
 .. ipython:: python
 
-   xr.open_mfdataset("tutorial_dataset_1d/*.sdf", preprocess=SDFPreprocess())
+   xr.open_mfdataset(
+      "tutorial_dataset_1d/*.sdf",
+      join="outer",
+      compat="no_conflicts",
+      preprocess=sdfxr.SDFPreprocess())
 
 Reading particle data
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
-   It is **not recommended** to use :func:`xarray.open_mfdataset` or :func:`open_mfdataset` to load particle data from multiple SDF outputs. The number of particles often varies between outputs, which can lead to inconsistent array shapes that these functions cannot handle. Instead, consider loading each file individually and then concatenating them manually.
+   It is **not recommended** to use :func:`xarray.open_mfdataset` or
+   :func:`sdf_xarray.open_mfdataset` to load particle data from multiple
+   SDF outputs. The number of particles often varies between outputs,
+   which can lead to inconsistent array shapes that these functions
+   cannot handle. Instead, consider loading each file individually and
+   then concatenating them manually.
 
 .. note::
-   When loading multiple probes from a single SDF file, you **must** use the `probe_names` parameter to assign a unique name to each. For example, use `probe_names=["Front_Electron_Probe", "Back_Electron_Probe"]`. Failing to do so will result in dimension name conflicts.
+   When loading multiple probes from a single SDF file, you **must** use the
+   ``probe_names`` parameter to assign a unique name to each. For example,
+   use ``probe_names=["Front_Electron_Probe", "Back_Electron_Probe"]``.
+   Failing to do so will result in dimension name conflicts.
 
 By default, particle data isn't kept as it takes up a lot of space.
 Pass ``keep_particles=True`` as a keyword argument to
@@ -85,7 +105,7 @@ looking at when you call ``.values``
 
 .. ipython:: python
 
-   ds = xr.open_mfdataset("tutorial_dataset_1d/*.sdf", preprocess=SDFPreprocess())
+   ds = sdfxr.open_mfdataset("tutorial_dataset_1d/*.sdf")
 
    ds["Electric_Field_Ex"]
 

--- a/docs/unit_conversion.rst
+++ b/docs/unit_conversion.rst
@@ -38,8 +38,7 @@ import, the ``xarray.Dataset.pint`` accessor will not be initialised.
 
 .. ipython:: python
 
-    import xarray as xr
-    from sdf_xarray import SDFPreprocess
+    from sdf_xarray import open_mfdataset
     import pint_xarray
 
 In the following example we will extract the time-resolved total particle
@@ -72,7 +71,7 @@ be removed.
 
 .. ipython:: python
 
-    with xr.open_mfdataset("tutorial_dataset_1d/*.sdf", preprocess=SDFPreprocess()) as ds:
+    with open_mfdataset("tutorial_dataset_1d/*.sdf") as ds:
         total_particle_energy = ds["Total_Particle_Energy_Electron"]
 
     total_particle_energy

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -149,7 +149,9 @@ def open_mfdataset(
 
     for df in all_dfs:
         for da in df:
-            df[da] = df[da].expand_dims(dim={var_times_map[str(da)]: [df.attrs["time"]]})
+            df[da] = df[da].expand_dims(
+                dim={var_times_map[str(da)]: [df.attrs["time"]]}
+            )
         for coord in df.coords:
             if df.coords[coord].attrs.get("point_data", False):
                 # We need to undo our renaming of the coordinates
@@ -181,7 +183,9 @@ def make_time_dims(path_glob):
             for key in sdf_file.variables:
                 vars_count[_rename_with_underscore(key)].append(sdf_file.header["time"])
             for grid in sdf_file.grids.values():
-                vars_count[_rename_with_underscore(grid.name)].append(sdf_file.header["time"])
+                vars_count[_rename_with_underscore(grid.name)].append(
+                    sdf_file.header["time"]
+                )
 
     # Count the unique set of lists of times
     times_count = Counter(tuple(v) for v in vars_count.values())
@@ -410,7 +414,9 @@ class SDFDataStore(AbstractDataStore):
                     name in key for name in self.probe_names
                 )
                 name_processor = (
-                    _rename_with_underscore if is_probe_name_match else _grid_species_name
+                    _rename_with_underscore
+                    if is_probe_name_match
+                    else _grid_species_name
                 )
                 var_coords = (f"ID_{_process_grid_name(key, name_processor)}",)
             else:
@@ -435,7 +441,9 @@ class SDFDataStore(AbstractDataStore):
                 grid_mid = self.ds.grids[value.grid_mid]
                 grid_mid_base_name = _process_grid_name(grid_mid.name, _norm_grid_name)
                 for dim_size, dim_name in zip(grid_mid.shape, grid_mid.labels):
-                    dim_size_lookup[dim_name][dim_size] = f"{dim_name}_{grid_mid_base_name}"
+                    dim_size_lookup[dim_name][
+                        dim_size
+                    ] = f"{dim_name}_{grid_mid_base_name}"
 
                 var_coords = [
                     dim_size_lookup[dim_name][dim_size]

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -148,9 +148,7 @@ def open_mfdataset(
 
     for df in all_dfs:
         for da in df:
-            df[da] = df[da].expand_dims(
-                dim={var_times_map[str(da)]: [df.attrs["time"]]}
-            )
+            df[da] = df[da].expand_dims(dim={var_times_map[str(da)]: [df.attrs["time"]]})
         for coord in df.coords:
             if df.coords[coord].attrs.get("point_data", False):
                 # We need to undo our renaming of the coordinates
@@ -177,9 +175,7 @@ def make_time_dims(path_glob):
             for key in sdf_file.variables:
                 vars_count[_rename_with_underscore(key)].append(sdf_file.header["time"])
             for grid in sdf_file.grids.values():
-                vars_count[_rename_with_underscore(grid.name)].append(
-                    sdf_file.header["time"]
-                )
+                vars_count[_rename_with_underscore(grid.name)].append(sdf_file.header["time"])
 
     # Count the unique set of lists of times
     times_count = Counter(tuple(v) for v in vars_count.values())

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -140,7 +140,7 @@ def open_mfdataset(
             path_glob, keep_particles=keep_particles, probe_names=probe_names
         )
 
-    time_dims, var_times_map = make_time_dims(path_glob)
+    _, var_times_map = make_time_dims(path_glob)
     all_dfs = [
         xr.open_dataset(f, keep_particles=keep_particles, probe_names=probe_names)
         for f in path_glob

--- a/src/sdf_xarray/__init__.py
+++ b/src/sdf_xarray/__init__.py
@@ -87,9 +87,10 @@ def combine_datasets(path_glob: Iterable | str, **kwargs) -> xr.Dataset:
 
     return xr.open_mfdataset(
         path_glob,
-        data_vars="minimal",
-        coords="minimal",
-        compat="override",
+        data_vars="all",
+        coords="different",
+        compat="no_conflicts",
+        join="outer",
         preprocess=SDFPreprocess(),
         **kwargs,
     )
@@ -159,7 +160,12 @@ def open_mfdataset(
                 )
 
     return xr.combine_by_coords(
-        all_dfs, data_vars="minimal", combine_attrs="drop_conflicts"
+        all_dfs,
+        data_vars="all",
+        coords="different",
+        combine_attrs="drop_conflicts",
+        join="outer",
+        compat="no_conflicts",
     )
 
 
@@ -404,9 +410,7 @@ class SDFDataStore(AbstractDataStore):
                     name in key for name in self.probe_names
                 )
                 name_processor = (
-                    _rename_with_underscore
-                    if is_probe_name_match
-                    else _grid_species_name
+                    _rename_with_underscore if is_probe_name_match else _grid_species_name
                 )
                 var_coords = (f"ID_{_process_grid_name(key, name_processor)}",)
             else:
@@ -431,9 +435,7 @@ class SDFDataStore(AbstractDataStore):
                 grid_mid = self.ds.grids[value.grid_mid]
                 grid_mid_base_name = _process_grid_name(grid_mid.name, _norm_grid_name)
                 for dim_size, dim_name in zip(grid_mid.shape, grid_mid.labels):
-                    dim_size_lookup[dim_name][
-                        dim_size
-                    ] = f"{dim_name}_{grid_mid_base_name}"
+                    dim_size_lookup[dim_name][dim_size] = f"{dim_name}_{grid_mid_base_name}"
 
                 var_coords = [
                     dim_size_lookup[dim_name][dim_size]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,14 +1,17 @@
 import pathlib
 
+import numpy as np
+import numpy.testing as npt
 import pytest
 import xarray as xr
 
-from sdf_xarray import SDFPreprocess, _process_latex_name, open_mfdataset
+from sdf_xarray import SDFPreprocess, _process_latex_name, _resolve_glob, open_mfdataset
+
+# TODO Remove this once the new kwarg options are fully implemented
+xr.set_options(use_new_combine_kwarg_defaults=True)
 
 EXAMPLE_FILES_DIR = pathlib.Path(__file__).parent / "example_files_1D"
-EXAMPLE_MISMATCHED_FILES_DIR = (
-    pathlib.Path(__file__).parent / "example_mismatched_files"
-)
+EXAMPLE_MISMATCHED_FILES_DIR = pathlib.Path(__file__).parent / "example_mismatched_files"
 EXAMPLE_ARRAYS_DIR = pathlib.Path(__file__).parent / "example_array_no_grids"
 EXAMPLE_3D_DIST_FN = pathlib.Path(__file__).parent / "example_dist_fn"
 EXAMPLE_2D_PARTICLE_DATA = pathlib.Path(__file__).parent / "example_two_probes_2D"
@@ -84,14 +87,76 @@ def test_multiple_files_one_time_dim():
         assert tuple(absorption.coords) == ("time",)
         assert absorption.shape == (11,)
 
+        time = df["time"]
+        ex = df.isel(time=10)["Electric_Field_Ex"]
+        ex_values = ex.values
+        ex_x_coords = ex.coords["X_Grid_mid"].values
+        time_values = np.array(
+            [
+                5.466993e-14,
+                2.417504e-10,
+                4.833915e-10,
+                7.251419e-10,
+                9.667830e-10,
+                1.208533e-09,
+                1.450175e-09,
+                1.691925e-09,
+                1.933566e-09,
+                2.175316e-09,
+                2.416958e-09,
+            ]
+        )
+
+        expected_ex = np.array(
+            [
+                -3126528.47057157754898071289062500000000,
+                -3249643.37612255383282899856567382812500,
+                -6827013.11566223856061697006225585937500,
+                -9350267.99022011645138263702392578125000,
+                -1643592.58487333403900265693664550781250,
+                -2044751.41207189299166202545166015625000,
+                -4342811.34666103497147560119628906250000,
+                -10420841.38402196019887924194335937500000,
+                -7038801.83154528774321079254150390625000,
+                781649.31791684380732476711273193359375,
+                4476555.84853181242942810058593750000000,
+                5873312.79385650344192981719970703125000,
+                -95930.60501570138148963451385498046875,
+                -8977898.96547995693981647491455078125000,
+                -7951712.64987809769809246063232421875000,
+                -5655667.11171338520944118499755859375000,
+            ]
+        )
+        expected_ex_coords = np.array(
+            [
+                1.72522447e-05,
+                5.17567340e-05,
+                8.62612233e-05,
+                1.20765713e-04,
+                1.55270202e-04,
+                1.89774691e-04,
+                2.24279181e-04,
+                2.58783670e-04,
+                2.93288159e-04,
+                3.27792649e-04,
+                3.62297138e-04,
+                3.96801627e-04,
+                4.31306117e-04,
+                4.65810606e-04,
+                5.00315095e-04,
+                5.34819585e-04,
+            ]
+        )
+        npt.assert_allclose(time_values, time.values, rtol=1e-6)
+        npt.assert_array_equal(ex_values, expected_ex)
+        npt.assert_allclose(ex_x_coords, expected_ex_coords)
+
 
 def test_multiple_files_multiple_time_dims():
     with open_mfdataset(
         EXAMPLE_FILES_DIR.glob("*.sdf"), separate_times=True, keep_particles=True
     ) as df:
-        assert list(df["Electric_Field_Ex"].coords) != list(
-            df["Electric_Field_Ez"].coords
-        )
+        assert list(df["Electric_Field_Ex"].coords) != list(df["Electric_Field_Ez"].coords)
         assert df["Electric_Field_Ex"].shape == (11, 16)
         assert df["Electric_Field_Ez"].shape == (1, 16)
         assert df["Particles_Px_proton"].shape == (1, 1920)
@@ -159,22 +224,100 @@ def test_xr_erroring_on_mismatched_jobid_files():
             data_vars="minimal",
             coords="minimal",
             compat="override",
+            join="outer",
             preprocess=SDFPreprocess(),
         )
 
 
-def test_time_dim_units():
+def test_xr_multiple_files_data():
     with xr.open_mfdataset(
-        EXAMPLE_ARRAYS_DIR.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as df:
-        assert df["time"].units == "s"
-        assert df["time"].long_name == "Time"
-        assert df["time"].full_name == "time"
+        ex = df.isel(time=10)["Electric_Field_Ex"]
+        ex_values = ex.values
+        ex_x_coords = ex.coords["X_Grid_mid"].values
+
+        expected_ex = np.array(
+            [
+                -3126528.47057157754898071289062500000000,
+                -3249643.37612255383282899856567382812500,
+                -6827013.11566223856061697006225585937500,
+                -9350267.99022011645138263702392578125000,
+                -1643592.58487333403900265693664550781250,
+                -2044751.41207189299166202545166015625000,
+                -4342811.34666103497147560119628906250000,
+                -10420841.38402196019887924194335937500000,
+                -7038801.83154528774321079254150390625000,
+                781649.31791684380732476711273193359375,
+                4476555.84853181242942810058593750000000,
+                5873312.79385650344192981719970703125000,
+                -95930.60501570138148963451385498046875,
+                -8977898.96547995693981647491455078125000,
+                -7951712.64987809769809246063232421875000,
+                -5655667.11171338520944118499755859375000,
+            ]
+        )
+        expected_ex_coords = np.array(
+            [
+                1.72522447e-05,
+                5.17567340e-05,
+                8.62612233e-05,
+                1.20765713e-04,
+                1.55270202e-04,
+                1.89774691e-04,
+                2.24279181e-04,
+                2.58783670e-04,
+                2.93288159e-04,
+                3.27792649e-04,
+                3.62297138e-04,
+                3.96801627e-04,
+                4.31306117e-04,
+                4.65810606e-04,
+                5.00315095e-04,
+                5.34819585e-04,
+            ]
+        )
+        npt.assert_array_equal(ex_values, expected_ex)
+        npt.assert_allclose(ex_x_coords, expected_ex_coords)
 
 
-def test_latex_rename_variables():
+def test_xr_time_dim():
+    with xr.open_mfdataset(
+        EXAMPLE_FILES_DIR.glob("*.sdf"),
+        join="outer",
+        preprocess=SDFPreprocess(),
+    ) as df:
+        time = df["time"]
+        assert time.units == "s"
+        assert time.long_name == "Time"
+        assert time.full_name == "time"
+
+        time_values = np.array(
+            [
+                5.466993e-14,
+                2.417504e-10,
+                4.833915e-10,
+                7.251419e-10,
+                9.667830e-10,
+                1.208533e-09,
+                1.450175e-09,
+                1.691925e-09,
+                1.933566e-09,
+                2.175316e-09,
+                2.416958e-09,
+            ]
+        )
+
+        npt.assert_allclose(time_values, time.values, rtol=1e-6)
+
+
+def test_xr_latex_rename_variables():
     with xr.open_mfdataset(
         EXAMPLE_ARRAYS_DIR.glob("*.sdf"),
+        join="outer",
         preprocess=SDFPreprocess(),
         keep_particles=True,
     ) as df:
@@ -187,15 +330,9 @@ def test_latex_rename_variables():
         assert df["Current_Jx"].attrs["long_name"] == "Current $J_x$"
         assert df["Current_Jy"].attrs["long_name"] == "Current $J_y$"
         assert df["Current_Jz"].attrs["long_name"] == "Current $J_z$"
-        assert (
-            df["Particles_Px_Electron"].attrs["long_name"] == "Particles $P_x$ Electron"
-        )
-        assert (
-            df["Particles_Py_Electron"].attrs["long_name"] == "Particles $P_y$ Electron"
-        )
-        assert (
-            df["Particles_Pz_Electron"].attrs["long_name"] == "Particles $P_z$ Electron"
-        )
+        assert df["Particles_Px_Electron"].attrs["long_name"] == "Particles $P_x$ Electron"
+        assert df["Particles_Py_Electron"].attrs["long_name"] == "Particles $P_y$ Electron"
+        assert df["Particles_Pz_Electron"].attrs["long_name"] == "Particles $P_z$ Electron"
 
         assert _process_latex_name("Example") == "Example"
         assert _process_latex_name("PxTest") == "PxTest"
@@ -210,7 +347,7 @@ def test_latex_rename_variables():
         )
 
 
-def test_arrays_with_no_grids():
+def test_xr_arrays_with_no_grids():
     with xr.open_dataset(EXAMPLE_ARRAYS_DIR / "0001.sdf") as df:
         laser_phase = "laser_x_min_phase"
         assert laser_phase in df
@@ -221,9 +358,11 @@ def test_arrays_with_no_grids():
         assert df[random_states].shape == (8,)
 
 
-def test_arrays_with_no_grids_multifile():
+def test_xr_arrays_with_no_grids_multifile():
     with xr.open_mfdataset(
-        EXAMPLE_ARRAYS_DIR.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_ARRAYS_DIR.glob("*.sdf"),
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as df:
         laser_phase = "laser_x_min_phase"
         assert laser_phase in df
@@ -234,20 +373,20 @@ def test_arrays_with_no_grids_multifile():
         assert df[random_states].shape == (2, 8)
 
 
-def test_3d_distribution_function():
+def test_xr_3d_distribution_function():
     with xr.open_dataset(EXAMPLE_3D_DIST_FN / "0000.sdf") as df:
         distribution_function = "dist_fn_x_px_py_Electron"
         assert df[distribution_function].shape == (16, 20, 20)
 
 
-def test_drop_variables():
+def test_xr_drop_variables():
     with xr.open_dataset(
         EXAMPLE_FILES_DIR / "0000.sdf", drop_variables=["Electric_Field_Ex"]
     ) as df:
         assert "Electric_Field_Ex" not in df
 
 
-def test_drop_variables_multiple():
+def test_xr_drop_variables_multiple():
     with xr.open_dataset(
         EXAMPLE_FILES_DIR / "0000.sdf",
         drop_variables=["Electric_Field_Ex", "Electric_Field_Ey"],
@@ -256,7 +395,7 @@ def test_drop_variables_multiple():
         assert "Electric_Field_Ey" not in df
 
 
-def test_drop_variables_original():
+def test_xr_drop_variables_original():
     with xr.open_dataset(
         EXAMPLE_FILES_DIR / "0000.sdf",
         drop_variables=["Electric_Field/Ex", "Electric_Field/Ey"],
@@ -265,7 +404,7 @@ def test_drop_variables_original():
         assert "Electric_Field_Ey" not in df
 
 
-def test_drop_variables_mixed():
+def test_xr_drop_variables_mixed():
     with xr.open_dataset(
         EXAMPLE_FILES_DIR / "0000.sdf",
         drop_variables=["Electric_Field/Ex", "Electric_Field_Ey"],
@@ -274,14 +413,12 @@ def test_drop_variables_mixed():
         assert "Electric_Field_Ey" not in df
 
 
-def test_erroring_drop_variables():
+def test_xr_erroring_drop_variables():
     with pytest.raises(KeyError):
-        xr.open_dataset(
-            EXAMPLE_FILES_DIR / "0000.sdf", drop_variables=["Electric_Field/E"]
-        )
+        xr.open_dataset(EXAMPLE_FILES_DIR / "0000.sdf", drop_variables=["Electric_Field/E"])
 
 
-def test_loading_multiple_probes():
+def test_xr_loading_multiple_probes():
     with xr.open_dataset(
         EXAMPLE_2D_PARTICLE_DATA / "0002.sdf",
         keep_particles=True,
@@ -293,7 +430,7 @@ def test_loading_multiple_probes():
         assert "ID_Electron_Back_Probe_Px" in df.dims
 
 
-def test_loading_one_probe_drop_second_probe():
+def test_xr_oading_one_probe_drop_second_probe():
     with xr.open_dataset(
         EXAMPLE_2D_PARTICLE_DATA / "0002.sdf",
         keep_particles=True,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -11,7 +11,9 @@ from sdf_xarray import SDFPreprocess, _process_latex_name, _resolve_glob, open_m
 xr.set_options(use_new_combine_kwarg_defaults=True)
 
 EXAMPLE_FILES_DIR = pathlib.Path(__file__).parent / "example_files_1D"
-EXAMPLE_MISMATCHED_FILES_DIR = pathlib.Path(__file__).parent / "example_mismatched_files"
+EXAMPLE_MISMATCHED_FILES_DIR = (
+    pathlib.Path(__file__).parent / "example_mismatched_files"
+)
 EXAMPLE_ARRAYS_DIR = pathlib.Path(__file__).parent / "example_array_no_grids"
 EXAMPLE_3D_DIST_FN = pathlib.Path(__file__).parent / "example_dist_fn"
 EXAMPLE_2D_PARTICLE_DATA = pathlib.Path(__file__).parent / "example_two_probes_2D"
@@ -156,7 +158,9 @@ def test_multiple_files_multiple_time_dims():
     with open_mfdataset(
         EXAMPLE_FILES_DIR.glob("*.sdf"), separate_times=True, keep_particles=True
     ) as df:
-        assert list(df["Electric_Field_Ex"].coords) != list(df["Electric_Field_Ez"].coords)
+        assert list(df["Electric_Field_Ex"].coords) != list(
+            df["Electric_Field_Ez"].coords
+        )
         assert df["Electric_Field_Ex"].shape == (11, 16)
         assert df["Electric_Field_Ez"].shape == (1, 16)
         assert df["Particles_Px_proton"].shape == (1, 1920)
@@ -330,9 +334,15 @@ def test_xr_latex_rename_variables():
         assert df["Current_Jx"].attrs["long_name"] == "Current $J_x$"
         assert df["Current_Jy"].attrs["long_name"] == "Current $J_y$"
         assert df["Current_Jz"].attrs["long_name"] == "Current $J_z$"
-        assert df["Particles_Px_Electron"].attrs["long_name"] == "Particles $P_x$ Electron"
-        assert df["Particles_Py_Electron"].attrs["long_name"] == "Particles $P_y$ Electron"
-        assert df["Particles_Pz_Electron"].attrs["long_name"] == "Particles $P_z$ Electron"
+        assert (
+            df["Particles_Px_Electron"].attrs["long_name"] == "Particles $P_x$ Electron"
+        )
+        assert (
+            df["Particles_Py_Electron"].attrs["long_name"] == "Particles $P_y$ Electron"
+        )
+        assert (
+            df["Particles_Pz_Electron"].attrs["long_name"] == "Particles $P_z$ Electron"
+        )
 
         assert _process_latex_name("Example") == "Example"
         assert _process_latex_name("PxTest") == "PxTest"
@@ -415,7 +425,9 @@ def test_xr_drop_variables_mixed():
 
 def test_xr_erroring_drop_variables():
     with pytest.raises(KeyError):
-        xr.open_dataset(EXAMPLE_FILES_DIR / "0000.sdf", drop_variables=["Electric_Field/E"])
+        xr.open_dataset(
+            EXAMPLE_FILES_DIR / "0000.sdf", drop_variables=["Electric_Field/E"]
+        )
 
 
 def test_xr_loading_multiple_probes():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -99,7 +99,59 @@ def test_multiple_files_multiple_time_dims():
         assert df["Absorption_Total_Laser_Energy_Injected"].shape == (11,)
 
 
-def test_erroring_on_mismatched_jobid_files():
+def test_resolve_glob_from_string_pattern():
+    pattern = str(EXAMPLE_FILES_DIR / "*.sdf")
+    result = _resolve_glob(pattern)
+    expected = sorted(EXAMPLE_FILES_DIR.glob("*.sdf"))
+    assert result == expected
+
+
+def test_resolve_glob_from_path_glob():
+    pattern = EXAMPLE_FILES_DIR.glob("*.sdf")
+    result = _resolve_glob(pattern)
+    expected = sorted(EXAMPLE_FILES_DIR.glob("*.sdf"))
+    assert result == expected
+
+
+def test_resolve_glob_from_path_missing_glob():
+    pattern = EXAMPLE_FILES_DIR
+    with pytest.raises(FileNotFoundError):
+        _resolve_glob(pattern)
+
+
+def test_resolve_glob_from_path_list():
+    pattern = [EXAMPLE_FILES_DIR / "0000.sdf"]
+    result = _resolve_glob(pattern)
+    expected = [EXAMPLE_FILES_DIR / "0000.sdf"]
+    assert result == expected
+
+
+def test_resolve_glob_from_path_list_multiple():
+    pattern = [EXAMPLE_FILES_DIR / "0000.sdf", EXAMPLE_FILES_DIR / "0001.sdf"]
+    result = _resolve_glob(pattern)
+    expected = [EXAMPLE_FILES_DIR / "0000.sdf", EXAMPLE_FILES_DIR / "0001.sdf"]
+    assert result == expected
+
+
+def test_resolve_glob_from_path_list_multiple_unordered():
+    pattern = [EXAMPLE_FILES_DIR / "0001.sdf", EXAMPLE_FILES_DIR / "0000.sdf"]
+    result = _resolve_glob(pattern)
+    expected = [EXAMPLE_FILES_DIR / "0000.sdf", EXAMPLE_FILES_DIR / "0001.sdf"]
+    assert result == expected
+
+
+def test_resolve_glob_from_path_list_multiple_duplicates():
+    pattern = [
+        EXAMPLE_FILES_DIR / "0000.sdf",
+        EXAMPLE_FILES_DIR / "0000.sdf",
+        EXAMPLE_FILES_DIR / "0001.sdf",
+    ]
+    result = _resolve_glob(pattern)
+    expected = [EXAMPLE_FILES_DIR / "0000.sdf", EXAMPLE_FILES_DIR / "0001.sdf"]
+    assert result == expected
+
+
+def test_xr_erroring_on_mismatched_jobid_files():
     with pytest.raises(ValueError):  # noqa: PT011
         xr.open_mfdataset(
             EXAMPLE_MISMATCHED_FILES_DIR.glob("*.sdf"),

--- a/tests/test_epoch_accessor.py
+++ b/tests/test_epoch_accessor.py
@@ -8,14 +8,15 @@ import xarray as xr
 from matplotlib.animation import PillowWriter
 
 import sdf_xarray.plotting as sxp
-from sdf_xarray import SDFPreprocess
+from sdf_xarray import SDFPreprocess, open_mfdataset
 
 mpl.use("Agg")
 
+# TODO Remove this once the new kwarg options are fully implemented
+xr.set_options(use_new_combine_kwarg_defaults=True)
+
 EXAMPLE_FILES_DIR_1D = pathlib.Path(__file__).parent / "example_files_1D"
-EXAMPLE_FILES_DIR_2D_MW = (
-    pathlib.Path(__file__).parent / "example_files_2D_moving_window"
-)
+EXAMPLE_FILES_DIR_2D_MW = pathlib.Path(__file__).parent / "example_files_2D_moving_window"
 
 
 def test_animation_accessor():
@@ -30,8 +31,24 @@ def test_animation_accessor():
 
 
 def test_animate_headless():
+    with open_mfdataset(EXAMPLE_FILES_DIR_1D.glob("*.sdf")) as ds:
+        anim = ds["Derived_Number_Density_electron"].epoch.animate()
+
+        # Specify a custom writable temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file_path = f"{temp_dir}/output.gif"
+            try:
+                anim.save(temp_file_path, writer=PillowWriter(fps=2))
+            except Exception as e:
+                pytest.fail(f"animate().save() failed in headless mode: {e}")
+
+
+def test_xr_animate_headless():
     with xr.open_mfdataset(
-        EXAMPLE_FILES_DIR_1D.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR_1D.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as ds:
         anim = ds["Derived_Number_Density_electron"].epoch.animate()
 
@@ -44,9 +61,12 @@ def test_animate_headless():
                 pytest.fail(f"animate().save() failed in headless mode: {e}")
 
 
-def test_get_frame_title_no_optional_params():
+def test_xr_get_frame_title_no_optional_params():
     with xr.open_mfdataset(
-        EXAMPLE_FILES_DIR_1D.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR_1D.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as ds:
         data = ds["Derived_Number_Density_electron"]
         expected_result = "time = 5.47e-14 [s]"
@@ -54,9 +74,12 @@ def test_get_frame_title_no_optional_params():
         assert expected_result == result
 
 
-def test_get_frame_title_sdf_name():
+def test_xr_get_frame_title_sdf_name():
     with xr.open_mfdataset(
-        EXAMPLE_FILES_DIR_1D.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR_1D.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as ds:
         data = ds["Derived_Number_Density_electron"]
         expected_result = "time = 5.47e-14 [s], 0000.sdf"
@@ -64,9 +87,12 @@ def test_get_frame_title_sdf_name():
         assert expected_result == result
 
 
-def test_get_frame_title_custom_title():
+def test_xr_get_frame_title_custom_title():
     with xr.open_mfdataset(
-        EXAMPLE_FILES_DIR_1D.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR_1D.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as ds:
         data = ds["Derived_Number_Density_electron"]
         expected_result = "Test Title, time = 5.47e-14 [s]"
@@ -74,23 +100,26 @@ def test_get_frame_title_custom_title():
         assert expected_result == result
 
 
-def test_get_frame_title_custom_title_and_sdf_name():
+def test_xr_get_frame_title_custom_title_and_sdf_name():
     with xr.open_mfdataset(
-        EXAMPLE_FILES_DIR_1D.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR_1D.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as ds:
         data = ds["Derived_Number_Density_electron"]
         expected_result = "Test Title, time = 5.47e-14 [s], 0000.sdf"
-        result = sxp.get_frame_title(
-            data, 0, display_sdf_name=True, title_custom="Test Title"
-        )
+        result = sxp.get_frame_title(data, 0, display_sdf_name=True, title_custom="Test Title")
         assert expected_result == result
 
 
-def test_calculate_window_boundaries_1D():
+def test_xr_calculate_window_boundaries_1D():
     with xr.open_mfdataset(
         EXAMPLE_FILES_DIR_2D_MW.glob("*.sdf"),
         preprocess=SDFPreprocess(),
         combine="nested",
+        compat="no_conflicts",
+        join="outer",
     ) as ds:
         data = ds["Derived_Number_Density_electron"][:, :, 50]
         expected_result = np.array(
@@ -100,11 +129,13 @@ def test_calculate_window_boundaries_1D():
         assert result == pytest.approx(expected_result, abs=0.1)
 
 
-def test_calculate_window_boundaries_2D():
+def test_xr_calculate_window_boundaries_2D():
     with xr.open_mfdataset(
         EXAMPLE_FILES_DIR_2D_MW.glob("*.sdf"),
         preprocess=SDFPreprocess(),
         combine="nested",
+        compat="no_conflicts",
+        join="outer",
     ) as ds:
         data = ds["Derived_Number_Density_electron"]
         expected_result = np.array(
@@ -114,11 +145,13 @@ def test_calculate_window_boundaries_2D():
         assert result == pytest.approx(expected_result, abs=0.1)
 
 
-def test_calculate_window_boundaries_1D_xlim():
+def test_xr_calculate_window_boundaries_1D_xlim():
     with xr.open_mfdataset(
         EXAMPLE_FILES_DIR_2D_MW.glob("*.sdf"),
         preprocess=SDFPreprocess(),
         combine="nested",
+        compat="no_conflicts",
+        join="outer",
     ) as ds:
         data = ds["Derived_Number_Density_electron"][:, :, 50]
         expected_result = np.array(
@@ -128,11 +161,13 @@ def test_calculate_window_boundaries_1D_xlim():
         assert result == pytest.approx(expected_result, abs=0.1)
 
 
-def test_calculate_window_boundaries_2D_xlim():
+def test_xr_calculate_window_boundaries_2D_xlim():
     with xr.open_mfdataset(
         EXAMPLE_FILES_DIR_2D_MW.glob("*.sdf"),
         preprocess=SDFPreprocess(),
         combine="nested",
+        compat="no_conflicts",
+        join="outer",
     ) as ds:
         data = ds["Derived_Number_Density_electron"]
         expected_result = np.array(
@@ -142,9 +177,12 @@ def test_calculate_window_boundaries_2D_xlim():
         assert result == pytest.approx(expected_result, abs=0.1)
 
 
-def test_compute_global_limits():
+def test_xr_compute_global_limits():
     with xr.open_mfdataset(
-        EXAMPLE_FILES_DIR_1D.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR_1D.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as ds:
         result_min, result_max = sxp.compute_global_limits(
             ds["Derived_Number_Density_electron"]
@@ -155,9 +193,12 @@ def test_compute_global_limits():
         assert result_max == pytest.approx(expected_result_max, abs=1e19)
 
 
-def test_compute_global_limits_percentile():
+def test_xr_compute_global_limits_percentile():
     with xr.open_mfdataset(
-        EXAMPLE_FILES_DIR_1D.glob("*.sdf"), preprocess=SDFPreprocess()
+        EXAMPLE_FILES_DIR_1D.glob("*.sdf"),
+        compat="no_conflicts",
+        join="outer",
+        preprocess=SDFPreprocess(),
     ) as ds:
         result_min, result_max = sxp.compute_global_limits(
             ds["Derived_Number_Density_electron"], 40, 45
@@ -168,11 +209,13 @@ def test_compute_global_limits_percentile():
         assert result_max == pytest.approx(expected_result_max, abs=1e18)
 
 
-def test_compute_global_limits_NaNs():
+def test_xr_compute_global_limits_NaNs():
     with xr.open_mfdataset(
         EXAMPLE_FILES_DIR_2D_MW.glob("*.sdf"),
         preprocess=SDFPreprocess(),
         combine="nested",
+        compat="no_conflicts",
+        join="outer",
     ) as ds:
         result_min, result_max = sxp.compute_global_limits(
             ds["Derived_Number_Density_electron"]

--- a/tests/test_epoch_accessor.py
+++ b/tests/test_epoch_accessor.py
@@ -16,7 +16,9 @@ mpl.use("Agg")
 xr.set_options(use_new_combine_kwarg_defaults=True)
 
 EXAMPLE_FILES_DIR_1D = pathlib.Path(__file__).parent / "example_files_1D"
-EXAMPLE_FILES_DIR_2D_MW = pathlib.Path(__file__).parent / "example_files_2D_moving_window"
+EXAMPLE_FILES_DIR_2D_MW = (
+    pathlib.Path(__file__).parent / "example_files_2D_moving_window"
+)
 
 
 def test_animation_accessor():
@@ -109,7 +111,9 @@ def test_xr_get_frame_title_custom_title_and_sdf_name():
     ) as ds:
         data = ds["Derived_Number_Density_electron"]
         expected_result = "Test Title, time = 5.47e-14 [s], 0000.sdf"
-        result = sxp.get_frame_title(data, 0, display_sdf_name=True, title_custom="Test Title")
+        result = sxp.get_frame_title(
+            data, 0, display_sdf_name=True, title_custom="Test Title"
+        )
         assert expected_result == result
 
 


### PR DESCRIPTION
# xarray parameter default changes

This PR updates our usage to adapt to recent changes in `xarray`'s default parameter values for `open_mfdataset`. **These changes introduce breaking behaviour** for existing code that relied on the old defaults, so please review the new default behaviours below.

| **Parameter** | **Old**        | **New**    |
| ------------- | -------------- | ---------- |
| `data_vars`   | "all"          | None       |
| `coords`      | "different"    | "minimal"  |
| `compat`      | "no_conflicts" | "override" |
| `join`        | "outer"        | "exact"    |

## Detailed behaviour changes
- `data_vars` - which variables to concatenate together
    - **previously** (`"all"`):  All data variables will be concatenated.
	- **currently** (`None`): means `all` when concatenating along a new dimension, and `"minimal"` when concatenating along an existing dimension
- `coords` - which coordinate variables to concatenate together
	- **previously** (`"different"`): Coordinates which are not equal (ignoring attributes) across all datasets are also concatenated (as well as all for which dimension already appears). Beware: this option may load the data payload of coordinate variables into memory if they are not already loaded.
	- **currently** (`"minimal"`): Only coordinates in which the dimension already appears are included.
- `compat` - Indicates how to compare non-concatenated variables of the same name for potential conflicts.
	- **previously** (`"no_conflicts"`):  Only values which are not null in both datasets must be equal. The returned dataset then contains the combination of all non-null values.
	- **currently** (`"override"`): Skip comparing and pick variable from first dataset
- `join` - Indicates how to combine differing indexes (excluding dim) in objects
	- **previously** (`"outer"`): Use the union of object indexes
	- **currently** (`"exact"`): Instead of aligning, raise a `ValueError` when indexes to be aligned are not equal
## Required changes for users
Instead of using `xarray.open_mfdataset()`, we **strongly recommend** using the `sdf_xarray.open_mfdataset()` function which sets all the default parameters and calls the preprocess internally, simplifying your code and imports. You can still pass in any `kwargs` to override the defaults

```python
import xarray as xr
import sdf_xarray as sdfxr

# old usage of required params to run the code
ds = xr.open_mfdataset(
	"path/to/files/*.sdf",
	data_vars="minimal",
	coords="minimal",
	compat="no_conflicts",
	join="outer",
	preprocess=sdfxr.SDFPreprocess(),
)

# Recommended new usage
ds = sdfxr.open_dataset("path/to/files/*.sdf")
```
## Additional Fixes
- Updated the `combine_datasets` and `open_mfdataset` functions to be more inline with the old `xarray` parameters and expected by the user.
- Replaced error-prone `path_glob` in `open_mfdataset` with `_resolve_glob` which accepts either a string, a Path with a glob or a list of exact files.
- Upgraded existing tests to check actual data (I can't believe we were skipping this in the past!) and added new tests for `_resolve_glob`